### PR TITLE
Fixed issue when creating TCP config with OpenVPN.

### DIFF
--- a/auto_setup.sh
+++ b/auto_setup.sh
@@ -263,7 +263,7 @@ elif [[ $mode == 5 ]]; then
 		touch /root/$configName.ovpn
 
 		sed -i 's/1194/443/g' /root/$configName-TCP.ovpn
-		sed -i 's/udp/tcp/g' /etc/openvpn/TCP.conf
+		sed -i 's/proto udp/proto tcp/g' /etc/openvpn/$configName-TCP.conf
 		sed -i 's/dev tun/dev tun_tcp/g' /root/$configName-TCP.ovpn
 		sed -i 's/AES-128-GCM/CHACHA20-POLY1305/g' /root/$configName-TCP.ovpn
 


### PR DESCRIPTION
Fixed issue with sed that changed the wrong (non existing) file.
It was supposed to change "proto udp" to "proto tcp", its now fixed, i simply had to add "$configFile-TCP.ovpn" instead of "TCP.ovpn"